### PR TITLE
v2 API. Close alerts on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,16 @@ The plugin requires one parameter:
 
 Context variables usable in the subject line:
 
+* `${job.id}`: Job ID.
 * `${job.status}`: Job execution status (eg, FAILED, SUCCESS).
 * `${job.project}`: Job project name.
 * `${job.name}`: Job name.
 * `${job.group}`: Job group name.
-* `${job.user}`: User that executed the job.
+* `${job.username}`: User that executed the job.
+* `${job.user.email}`: Email address of user that executed the job.
 * `${job.execid}`: Job execution ID.
+* `${job.retryAttempt}`: Retry attempt number.
+* `${job.wasRetry}`: True if execution is retry.
 
 ## Installation
 
@@ -46,7 +50,7 @@ Or configure it at the instance level: $RDECK_BASE/etc/framework.properties
 |`api_key`|Any|None|Yes|Integration API Key|
 |`message`|Any|`${job.status} [${job.project}] \"${job.name}\"`|Yes|Message template.|
 |`description`|Any|`${job.status} [${job.project}] \"${job.name}\" run by ${job.user} (#${job.execid}) [${job.href}]`|No|Description template.|
-|`alias`|Any|`${job.project}-${job.name}-${job.execid}-${job.dateStartedUnixTime}`|No|alias template.|
+|`alias`|Any|`${job.id}`|No|alias template.|
 |`source`|Any|`${job.href}`|No|Source template.|
 |`proxy_host`|Project|None|Yes|Your egress proxy host.|
 |`proxy_port`|Project|None|If `proxy_host` is set|the port the network egress proxy accepts traffic on.|

--- a/src/OpsGenieNotification.groovy
+++ b/src/OpsGenieNotification.groovy
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 class DEFAULTS {
     static String OPSGENIE_URL = "https://api.opsgenie.com/v1/json/alert"
     static String MESSAGE_TEMPLATE = '${job.status} [${job.project}] \"${job.name}\"'
-    static String ALIAS_TEMPLATE = '${job.project}-${job.name}-${job.execid}-${job.dateStartedUnixTime}'
+    static String ALIAS_TEMPLATE = '${job.id}'
     static String DESCRIPTION_TEMPLATE = '${job.status} [${job.project}] \"${job.name}\" run by ${job.user} (#${job.execid}) [ ${job.href} ]'
     static String SOURCE_TEMPLATE = '${job.href}'
 }
@@ -149,7 +149,7 @@ rundeckPlugin(NotificationPlugin) {
 
         alias title: "Alias",
                 description: "Alias.",
-                efaultValue: DEFAULTS.ALIAS_TEMPLATE,
+                defaultValue: DEFAULTS.ALIAS_TEMPLATE,
                 required: false
 
         source title: "Source",


### PR DESCRIPTION
I made some tweaks to the plugin to automatically close Alerts when the job succeeds.

In the process I noticed that the v1 API endpoint will be completed shutdown in June 2018, and updated the plugin to use the v2 API.

Please take a look and let me know what you think